### PR TITLE
fix to protobuf

### DIFF
--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -79,9 +79,10 @@ class _Parser(json_format._Parser):  # type: ignore
     def ConvertMessage(self, value, message, path):
         full_name = message.DESCRIPTOR.full_name
         if full_name in self._custom_deserializers:
-            return self._custom_deserializers[full_name](value, message, path)
+            self._custom_deserializers[full_name](value, message, path)
+            return
         with _patched_convert_scalar_field_value():
-            return super().ConvertMessage(value, message, path)
+            super().ConvertMessage(value, message, path)
 
 
 # protobuf converts to/from b64 strings, but we prefer to stay as bytes.

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -10,6 +10,7 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from google.protobuf.timestamp_pb2 import Timestamp
 from pyspark.sql import Column
+from pyspark.sql import Row
 from pyspark.sql.functions import col
 from pyspark.sql.functions import udf
 from pyspark.sql.types import *

--- a/pbspark/_timestamp.py
+++ b/pbspark/_timestamp.py
@@ -2,32 +2,22 @@
 import calendar
 import datetime
 
+from google.protobuf.internal import well_known_types
 from google.protobuf.timestamp_pb2 import Timestamp
-
-_EPOCH_DATETIME = datetime.datetime.utcfromtimestamp(0)
-_NANOS_PER_MICROSECOND = 1000
-
-
-def _round_toward_zero(value, divider):
-    result = value // divider
-    remainder = value % divider
-    if result < 0 < remainder:
-        return result + 1
-    else:
-        return result
 
 
 def _to_datetime(message: Timestamp) -> datetime.datetime:
     """Convert a Timestamp to a python datetime."""
-    return _EPOCH_DATETIME + datetime.timedelta(
+    return well_known_types._EPOCH_DATETIME_NAIVE + datetime.timedelta(  # type: ignore[attr-defined]
         seconds=message.seconds,
-        microseconds=_round_toward_zero(message.nanos, _NANOS_PER_MICROSECOND),
+        microseconds=well_known_types._RoundTowardZero(  # type: ignore[attr-defined]
+            message.nanos,
+            well_known_types._NANOS_PER_MICROSECOND,  # type: ignore[attr-defined]
+        ),
     )
 
 
-def _from_datetime(dt):
+def _from_datetime(dt: datetime.datetime, timestamp: Timestamp, path: str):
     """Convert a python datetime to Timestamp."""
-    return Timestamp(
-        seconds=calendar.timegm(dt.utctimetuple()),
-        nanos=dt.microsecond * _NANOS_PER_MICROSECOND,
-    )
+    timestamp.seconds = calendar.timegm(dt.utctimetuple())
+    timestamp.nanos = dt.microsecond * well_known_types._NANOS_PER_MICROSECOND  # type: ignore[attr-defined]

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -200,6 +200,7 @@ def test_round_trip(example, spark):
     )
     df_unflattened.show()
     assert dfs.schema == df_unflattened.schema
+    assert dfs.collect() == df_unflattened.collect()
     df_again = df_unflattened.select(
         mc.to_protobuf(df_unflattened.value, ExampleMessage).alias("value")
     )


### PR DESCRIPTION
* Fixes bytes encoding. We are using a ByteType which is for a single byte (!). We actually want to use BinaryType for the proto bytes type. This also fixes the encoding to cast the `bytearray` to the `bytes` type.
* Fixes message decoding. Previously we were returning new messages but that's not how decoding works (!). The Parser's `ConvertMessage` is passed a message instance, and the parsing function should populate it, rather than return a new one.
* Use protobuf's constants for timestamp conversion. Previously we were copying code but now we just reference the objects from the `well_known_types` module.
* Fix the encoder to convert spark Rows to dictionaries.
* Fix the roundtrip test. Actually assert that the resulting data is the same as the original.