### PR TITLE
add recursive test; simplify custom serializers

### DIFF
--- a/example/example.proto
+++ b/example/example.proto
@@ -53,3 +53,8 @@ message ExampleMessage {
   google.protobuf.Duration duration = 23;
   DecimalMessage decimal = 24;
 }
+
+message RecursiveMessage {
+  string note = 1;
+  RecursiveMessage message = 2;
+}

--- a/example/example_pb2.py
+++ b/example/example_pb2.py
@@ -17,7 +17,7 @@ from google.protobuf import duration_pb2 as google_dot_protobuf_dot_duration__pb
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x15\x65xample/example.proto\x12\x07\x65xample\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto"@\n\rSimpleMessage\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08quantity\x18\x02 \x01(\x03\x12\x0f\n\x07measure\x18\x03 \x01(\x02"+\n\rNestedMessage\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t"\x1f\n\x0e\x44\x65\x63imalMessage\x12\r\n\x05value\x18\x01 \x01(\t"\xb7\x05\n\x0e\x45xampleMessage\x12\r\n\x05int32\x18\x01 \x01(\x05\x12\r\n\x05int64\x18\x02 \x01(\x03\x12\x0e\n\x06uint32\x18\x03 \x01(\r\x12\x0e\n\x06uint64\x18\x04 \x01(\x04\x12\x0e\n\x06\x64ouble\x18\x05 \x01(\x01\x12\r\n\x05\x66loat\x18\x06 \x01(\x02\x12\x0c\n\x04\x62ool\x18\x07 \x01(\x08\x12.\n\x04\x65num\x18\x08 \x01(\x0e\x32 .example.ExampleMessage.SomeEnum\x12\x0e\n\x06string\x18\t \x01(\t\x12&\n\x06nested\x18\n \x01(\x0b\x32\x16.example.NestedMessage\x12\x12\n\nstringlist\x18\x0b \x03(\t\x12\r\n\x05\x62ytes\x18\x0c \x01(\x0c\x12\x10\n\x08sfixed32\x18\r \x01(\x0f\x12\x10\n\x08sfixed64\x18\x0e \x01(\x10\x12\x0e\n\x06sint32\x18\x0f \x01(\x11\x12\x0e\n\x06sint64\x18\x10 \x01(\x12\x12\x0f\n\x07\x66ixed32\x18\x11 \x01(\x07\x12\x0f\n\x07\x66ixed64\x18\x12 \x01(\x06\x12\x15\n\x0boneofstring\x18\x13 \x01(\tH\x00\x12\x14\n\noneofint32\x18\x14 \x01(\x05H\x00\x12-\n\x03map\x18\x15 \x03(\x0b\x32 .example.ExampleMessage.MapEntry\x12-\n\ttimestamp\x18\x16 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\x08\x64uration\x18\x17 \x01(\x0b\x32\x19.google.protobuf.Duration\x12(\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32\x17.example.DecimalMessage\x1a*\n\x08MapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"2\n\x08SomeEnum\x12\x0f\n\x0bunspecified\x10\x00\x12\t\n\x05\x66irst\x10\x01\x12\n\n\x06second\x10\x02\x42\x07\n\x05oneofb\x06proto3'
+    b'\n\x15\x65xample/example.proto\x12\x07\x65xample\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto"@\n\rSimpleMessage\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08quantity\x18\x02 \x01(\x03\x12\x0f\n\x07measure\x18\x03 \x01(\x02"+\n\rNestedMessage\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t"\x1f\n\x0e\x44\x65\x63imalMessage\x12\r\n\x05value\x18\x01 \x01(\t"\xb7\x05\n\x0e\x45xampleMessage\x12\r\n\x05int32\x18\x01 \x01(\x05\x12\r\n\x05int64\x18\x02 \x01(\x03\x12\x0e\n\x06uint32\x18\x03 \x01(\r\x12\x0e\n\x06uint64\x18\x04 \x01(\x04\x12\x0e\n\x06\x64ouble\x18\x05 \x01(\x01\x12\r\n\x05\x66loat\x18\x06 \x01(\x02\x12\x0c\n\x04\x62ool\x18\x07 \x01(\x08\x12.\n\x04\x65num\x18\x08 \x01(\x0e\x32 .example.ExampleMessage.SomeEnum\x12\x0e\n\x06string\x18\t \x01(\t\x12&\n\x06nested\x18\n \x01(\x0b\x32\x16.example.NestedMessage\x12\x12\n\nstringlist\x18\x0b \x03(\t\x12\r\n\x05\x62ytes\x18\x0c \x01(\x0c\x12\x10\n\x08sfixed32\x18\r \x01(\x0f\x12\x10\n\x08sfixed64\x18\x0e \x01(\x10\x12\x0e\n\x06sint32\x18\x0f \x01(\x11\x12\x0e\n\x06sint64\x18\x10 \x01(\x12\x12\x0f\n\x07\x66ixed32\x18\x11 \x01(\x07\x12\x0f\n\x07\x66ixed64\x18\x12 \x01(\x06\x12\x15\n\x0boneofstring\x18\x13 \x01(\tH\x00\x12\x14\n\noneofint32\x18\x14 \x01(\x05H\x00\x12-\n\x03map\x18\x15 \x03(\x0b\x32 .example.ExampleMessage.MapEntry\x12-\n\ttimestamp\x18\x16 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\x08\x64uration\x18\x17 \x01(\x0b\x32\x19.google.protobuf.Duration\x12(\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32\x17.example.DecimalMessage\x1a*\n\x08MapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"2\n\x08SomeEnum\x12\x0f\n\x0bunspecified\x10\x00\x12\t\n\x05\x66irst\x10\x01\x12\n\n\x06second\x10\x02\x42\x07\n\x05oneof"L\n\x10RecursiveMessage\x12\x0c\n\x04note\x18\x01 \x01(\t\x12*\n\x07message\x18\x02 \x01(\x0b\x32\x19.example.RecursiveMessageb\x06proto3'
 )
 
 
@@ -26,6 +26,7 @@ _NESTEDMESSAGE = DESCRIPTOR.message_types_by_name["NestedMessage"]
 _DECIMALMESSAGE = DESCRIPTOR.message_types_by_name["DecimalMessage"]
 _EXAMPLEMESSAGE = DESCRIPTOR.message_types_by_name["ExampleMessage"]
 _EXAMPLEMESSAGE_MAPENTRY = _EXAMPLEMESSAGE.nested_types_by_name["MapEntry"]
+_RECURSIVEMESSAGE = DESCRIPTOR.message_types_by_name["RecursiveMessage"]
 _EXAMPLEMESSAGE_SOMEENUM = _EXAMPLEMESSAGE.enum_types_by_name["SomeEnum"]
 SimpleMessage = _reflection.GeneratedProtocolMessageType(
     "SimpleMessage",
@@ -81,6 +82,17 @@ ExampleMessage = _reflection.GeneratedProtocolMessageType(
 _sym_db.RegisterMessage(ExampleMessage)
 _sym_db.RegisterMessage(ExampleMessage.MapEntry)
 
+RecursiveMessage = _reflection.GeneratedProtocolMessageType(
+    "RecursiveMessage",
+    (_message.Message,),
+    {
+        "DESCRIPTOR": _RECURSIVEMESSAGE,
+        "__module__": "example.example_pb2"
+        # @@protoc_insertion_point(class_scope:example.RecursiveMessage)
+    },
+)
+_sym_db.RegisterMessage(RecursiveMessage)
+
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
@@ -98,4 +110,6 @@ if _descriptor._USE_C_DESCRIPTORS == False:
     _EXAMPLEMESSAGE_MAPENTRY._serialized_end = 878
     _EXAMPLEMESSAGE_SOMEENUM._serialized_start = 880
     _EXAMPLEMESSAGE_SOMEENUM._serialized_end = 930
+    _RECURSIVEMESSAGE._serialized_start = 941
+    _RECURSIVEMESSAGE._serialized_end = 1017
 # @@protoc_insertion_point(module_scope)

--- a/example/example_pb2.pyi
+++ b/example/example_pb2.pyi
@@ -274,3 +274,26 @@ class ExampleMessage(google.protobuf.message.Message):
     ) -> typing.Optional[typing_extensions.Literal["oneofstring", "oneofint32"]]: ...
 
 global___ExampleMessage = ExampleMessage
+
+class RecursiveMessage(google.protobuf.message.Message):
+    DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    NOTE_FIELD_NUMBER: builtins.int
+    MESSAGE_FIELD_NUMBER: builtins.int
+    note: typing.Text
+    @property
+    def message(self) -> global___RecursiveMessage: ...
+    def __init__(
+        self,
+        *,
+        note: typing.Text = ...,
+        message: typing.Optional[global___RecursiveMessage] = ...,
+    ) -> None: ...
+    def HasField(
+        self, field_name: typing_extensions.Literal["message", b"message"]
+    ) -> builtins.bool: ...
+    def ClearField(
+        self,
+        field_name: typing_extensions.Literal["message", b"message", "note", b"note"],
+    ) -> None: ...
+
+global___RecursiveMessage = RecursiveMessage

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,8 +11,8 @@ from example.example_pb2 import DecimalMessage
 from example.example_pb2 import RecursiveMessage
 
 
-def encode_recursive(message: RecursiveMessage, depth=0, max_depth=2):
-    if depth == max_depth:
+def encode_recursive(message: RecursiveMessage, depth=0):
+    if depth == 2:
         return json.dumps(MessageToDict(message))
     return {
         "note": message.note,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,24 @@
+"""These items are in a separate module so that spark workers can deserialize them.
+
+When referenced from the same file as the test a ModuleNotFoundError is raised.
+"""
+import json
+from decimal import Decimal
+
+from google.protobuf.json_format import MessageToDict
+
+from example.example_pb2 import DecimalMessage
+from example.example_pb2 import RecursiveMessage
+
+
+def encode_recursive(message: RecursiveMessage, depth=0, max_depth=2):
+    if depth == max_depth:
+        return json.dumps(MessageToDict(message))
+    return {
+        "note": message.note,
+        "message": encode_recursive(message.message, depth=depth + 1),
+    }
+
+
+def decimal_serializer(message: DecimalMessage):
+    return Decimal(message.value)


### PR DESCRIPTION
* Breaking: Allow return type instances to be passed to custom serializers rather than type class + init kwargs.
* Bugfix: `get_spark_schema` now returns properly when the descriptor passed has a registered custom serializer.
* Add a test for self-referencing messages and recursive custom serializer.