### PR TITLE
df_to/from_protobuf functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ message SimpleMessage {
 
 ### Basic conversion functions
 
-There are two helper functions, `df_to_protobuf` and `df_from_protobuf` which can be used if no custom conversion is necessary. They have a kwarg `expanded`, which will also take care of expanding/contracting the data between the single `value` column used in these examples and a dataframe which contains a column for each message field. `MessageConverter` instances (discussed below) can optionally be passed to these functions.
+There are two helper functions, `df_to_protobuf` and `df_from_protobuf` for use on dataframes. They have a kwarg `expanded`, which will also take care of expanding/contracting the data between the single `value` column used in these examples and a dataframe which contains a column for each message field. `MessageConverter` instances (discussed below) can optionally be passed to these functions.
 
 ```python
 from pyspark.sql.session import SparkSession
@@ -60,7 +60,7 @@ df_reencoded = df_to_protobuf(df_expanded, SimpleMessage, expanded=True)
 
 ### Column conversion using the `MessageConverter`
 
-Using an instance of `MessageConverter` we can decode the messages into spark `StructType` and then expand them.
+Using an instance of `MessageConverter` we can decode the column of encoded messages into a column of spark `StructType` and then expand the fields.
 
 ```python
 from pyspark.sql.session import SparkSession
@@ -88,13 +88,13 @@ df_expanded.schema
 # StructType(List(StructField(name,StringType,true),StructField(quantity,IntegerType,true),StructField(measure,FloatType,true))
 ```
 
-We can also re-encode them into protobuf strings.
+We can also re-encode them into protobuf.
 
 ```python
 df_reencoded = df_decoded.select(mc.to_protobuf(df_decoded.value, SimpleMessage).alias("value"))
 ```
 
-For expanded data, we can also (re-)encode after packing into a struct:
+For expanded data, we can also encode after packing into a struct column:
 
 ```python
 from pyspark.sql.functions import struct

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ df_expanded.show()
 # |hello|       5|   12.3|
 # +-----+--------+-------+
 
-# expanded=True will first pack data using `struct(df[c] for c in df.columns)`,
+# expanded=True will first pack data using `struct([df[c] for c in df.columns])`,
 # use this if the passed dataframe is already expanded
 df_reencoded = df_to_protobuf(df_expanded, SimpleMessage, expanded=True)
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ message SimpleMessage {
 }
 ```
 
-Using `pbspark` we can decode the messages into spark `StructType` and then flatten them.
+Using `pbspark` we can decode the messages into spark `StructType` and then expand them.
 
 ```python
 from pyspark.sql.session import SparkSession

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Internally, `pbspark` uses protobuf's `MessageToDict`, which deserializes everyt
 * protobuf's bytes type, which `MessageToDict` would decode to a base64-encoded string; `pbspark` will decode any bytes fields directly to a spark `BinaryType`.
 * protobuf's well known type, Timestamp type, which `MessageToDict` would decode to a string; `pbspark` will decode any Timestamp messages directly to a spark `TimestampType` (via python datetime objects).
 
-There are two helper functions, `df_to_protobuf` and `df_from_protobuf` which can be used if no custom conversion is necessary. They have a custom kwarg `expanded`, which will also take care of expanding/contracting the data between the single `value` column used in these examples and a dataframe which contains a column for each message field. `MessageConverter` instances can optionally be passed to these functions.
+There are two helper functions, `df_to_protobuf` and `df_from_protobuf` which can be used if no custom conversion is necessary. They have a kwarg `expanded`, which will also take care of expanding/contracting the data between the single `value` column used in these examples and a dataframe which contains a column for each message field. `MessageConverter` instances can optionally be passed to these functions.
 
 ```python
 example = SimpleMessage(name="hello", quantity=5, measure=12.3)

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ spark = SparkSession.builder.getOrCreate()
 
 example = SimpleMessage(name="hello", quantity=5, measure=12.3)
 data = [{"value": example.SerializeToString()}]
-df = spark.createDataFrame(data)
+df_encoded = spark.createDataFrame(data)
 
 mc = MessageConverter()
-df_decoded = df.select(mc.from_protobuf(df.value, SimpleMessage).alias("value"))
-df_flattened = df_decoded.select("value.*")
-df_flattened.show()
+df_decoded = df_encoded.select(mc.from_protobuf(df_encoded.value, SimpleMessage).alias("value"))
+df_expanded = df_decoded.select("value.*")
+df_expanded.show()
 
 # +-----+--------+-------+
 # | name|quantity|measure|
@@ -50,7 +50,7 @@ df_flattened.show()
 # |hello|       5|   12.3|
 # +-----+--------+-------+
 
-df_flattened.schema
+df_expanded.schema
 # StructType(List(StructField(name,StringType,true),StructField(quantity,IntegerType,true),StructField(measure,FloatType,true))
 ```
 
@@ -60,23 +60,37 @@ We can also re-encode them into protobuf strings.
 df_reencoded = df_decoded.select(mc.to_protobuf(df_decoded.value, SimpleMessage).alias("value"))
 ```
 
-For flattened data, we can also (re-)encode after collecting and packing into a struct:
+For expanded data, we can also (re-)encode after collecting and packing into a struct:
 
 ```python
 from pyspark.sql.functions import struct
 
-df_unflattened = df_flattened.select(
-    struct([df_flattened[c] for c in df_flattened.columns]).alias("value")
+df_unexpanded = df_expanded.select(
+    struct([df_expanded[c] for c in df_expanded.columns]).alias("value")
 )
-df_unflattened.show()
-df_reencoded = df_unflattened.select(
-    mc.to_protobuf(df_unflattened.value, SimpleMessage).alias("value")
+df_reencoded = df_unexpanded.select(
+    mc.to_protobuf(df_unexpanded.value, SimpleMessage).alias("value")
 )
 ```
 
 Internally, `pbspark` uses protobuf's `MessageToDict`, which deserializes everything into JSON compatible objects by default. The exceptions are
 * protobuf's bytes type, which `MessageToDict` would decode to a base64-encoded string; `pbspark` will decode any bytes fields directly to a spark `BinaryType`.
 * protobuf's well known type, Timestamp type, which `MessageToDict` would decode to a string; `pbspark` will decode any Timestamp messages directly to a spark `TimestampType` (via python datetime objects).
+
+There are two helper functions, `df_to_protobuf` and `df_from_protobuf` which can be used if no custom conversion is necessary. They have a custom kwarg `expanded`, which will also take care of expanding/contracting the data between the single `value` column used in these examples and a dataframe which contains a column for each message field. `MessageConverter` instances can optionally be passed to these functions.
+
+```python
+example = SimpleMessage(name="hello", quantity=5, measure=12.3)
+data = [{"value": example.SerializeToString()}]
+df_encoded = spark.createDataFrame(data)
+
+from pbspark import df_from_protobuf
+from pbspark import df_to_protobuf
+
+df_expanded = df_from_protobuf(df_encoded, SimpleMessage, expanded=True)
+
+df_reencoded = df_to_protobuf(df_expanded, SimpleMessage, expanded=True)
+```
 
 Custom serde is also supported. Suppose we use our `NestedMessage` from the repository's example and we want to serialize the key and value together into a single string.
 
@@ -115,9 +129,9 @@ spark = SparkSession(sc).builder.getOrCreate()
 
 message = ExampleMessage(nested=NestedMessage(key="hello", value="world"))
 data = [{"value": message.SerializeToString()}]
-df = spark.createDataFrame(data)
+df_encoded = spark.createDataFrame(data)
 
-df_decoded = df.select(mc.from_protobuf(df.value, ExampleMessage).alias("value"))
+df_decoded = df_encoded.select(mc.from_protobuf(df_encoded.value, ExampleMessage).alias("value"))
 # rather than a struct the value of `nested` is a string
 df_decoded.select("value.nested").show()
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ df_encoded = spark.createDataFrame(data)
 from pbspark import df_from_protobuf
 from pbspark import df_to_protobuf
 
+# expanded=True will perform a `.select("value.*")` after converting
 df_expanded = df_from_protobuf(df_encoded, SimpleMessage, expanded=True)
 
+# expanded=True will first pack data using `struct(df[c] for c in df.columns)`
 df_reencoded = df_to_protobuf(df_expanded, SimpleMessage, expanded=True)
 ```
 

--- a/pbspark/__init__.py
+++ b/pbspark/__init__.py
@@ -1,4 +1,6 @@
 from ._proto import MessageConverter
 from ._proto import df_from_protobuf
 from ._proto import df_to_protobuf
+from ._proto import from_protobuf
+from ._proto import to_protobuf
 from ._version import __version__

--- a/pbspark/__init__.py
+++ b/pbspark/__init__.py
@@ -1,2 +1,4 @@
 from ._proto import MessageConverter
+from ._proto import df_from_protobuf
+from ._proto import df_to_protobuf
 from ._version import __version__

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -10,7 +10,9 @@ from google.protobuf.descriptor_pool import DescriptorPool
 from google.protobuf.message import Message
 from google.protobuf.timestamp_pb2 import Timestamp
 from pyspark.sql import Column
+from pyspark.sql import DataFrame
 from pyspark.sql.functions import col
+from pyspark.sql.functions import struct
 from pyspark.sql.functions import udf
 from pyspark.sql.types import ArrayType
 from pyspark.sql.types import BinaryType
@@ -355,3 +357,51 @@ class MessageConverter:
         column = col(data) if isinstance(data, str) else data
         protobuf_encoder_udf = self.get_encoder_udf(message_type, options)
         return protobuf_encoder_udf(column)
+
+
+def df_from_protobuf(
+    df: DataFrame,
+    message_type: t.Type[Message],
+    options: t.Optional[dict] = None,
+    expanded: bool = False,
+    mc: MessageConverter = None,
+) -> DataFrame:
+    """Decode a dataframe of encoded protobuf.
+
+    If expanded, return a dataframe in which each field is its own column. Otherwise
+    return a dataframe with a single struct column named `value`.
+    """
+    mc = mc or MessageConverter()
+    df_decoded = df.select(
+        mc.from_protobuf(df.columns[0], message_type, options).alias("value")
+    )
+    if expanded:
+        df_decoded = df_decoded.select("value.*")
+    return df_decoded
+
+
+def df_to_protobuf(
+    df: DataFrame,
+    message_type: t.Type[Message],
+    options: t.Optional[dict] = None,
+    expanded: bool = False,
+    mc: MessageConverter = None,
+) -> DataFrame:
+    """Encode data in a dataframe to protobuf as column `value`.
+
+    If `expanded`, the passed dataframe columns will be packed into a struct before
+    converting. Otherwise it is assumed that the dataframe passed is a single column
+    of data already packed into a struct.
+
+    Returns a dataframe with a single column named `value` containing encoded data.
+    """
+    mc = mc or MessageConverter()
+    if expanded:
+        df_struct = df.select(
+            struct([df[c] for c in df.columns]).alias("value")  # type: ignore[arg-type]
+        )
+    else:
+        df_struct = df.select(col(df.columns[0]).alias("value"))
+    return df_struct.select(
+        mc.to_protobuf(df_struct.value, message_type, options).alias("value")
+    )

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -402,6 +402,7 @@ def df_to_protobuf(
         )
     else:
         df_struct = df.select(col(df.columns[0]).alias("value"))
-    return df_struct.select(
+    df_encoded = df_struct.select(
         mc.to_protobuf(df_struct.value, message_type, options).alias("value")
     )
+    return df_encoded

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -30,6 +30,8 @@ from example.example_pb2 import NestedMessage
 from example.example_pb2 import RecursiveMessage
 from pbspark._proto import MessageConverter
 from pbspark._proto import _patched_convert_scalar_field_value
+from pbspark._proto import df_from_protobuf
+from pbspark._proto import df_to_protobuf
 from tests.fixtures import decimal_serializer  # type: ignore[import]
 from tests.fixtures import encode_recursive
 
@@ -65,6 +67,11 @@ def spark():
     spark = SparkSession(sc).builder.getOrCreate()
     spark.conf.set("spark.sql.session.timeZone", "UTC")
     return spark
+
+
+@pytest.fixture(params=[True, False])
+def expanded(request):
+    return request.param
 
 
 def test_get_spark_schema():
@@ -251,3 +258,25 @@ def test_recursive_message(spark):
     dfs.show(truncate=False)
     data = dfs.collect()
     assert data[0].asDict(True)["value"] == expected
+
+
+def test_df_to_from_protobuf(example, spark, expanded):
+    data = [{"value": example.SerializeToString()}]
+
+    df = spark.createDataFrame(data)  # type: ignore[type-var]
+
+    df_decoded = df_from_protobuf(df, ExampleMessage, expanded=expanded)
+
+    mc = MessageConverter()
+    if expanded:
+        assert df_decoded.schema == mc.get_spark_schema(ExampleMessage)
+    else:
+        assert df_decoded.schema.fields[0].dataType == mc.get_spark_schema(
+            ExampleMessage
+        )
+
+    df_encoded = df_to_protobuf(df_decoded, ExampleMessage, expanded=expanded)
+
+    assert df_encoded.columns == ["value"]
+    assert df_encoded.schema == df.schema
+    assert df.collect() == df_encoded.collect()

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -289,12 +289,11 @@ def test_df_to_from_protobuf(example, spark, expanded):
     df_decoded = df_from_protobuf(df, ExampleMessage, expanded=expanded)
 
     mc = MessageConverter()
+    schema = mc.get_spark_schema(ExampleMessage)
     if expanded:
-        assert df_decoded.schema == mc.get_spark_schema(ExampleMessage)
+        assert df_decoded.schema == schema
     else:
-        assert df_decoded.schema.fields[0].dataType == mc.get_spark_schema(
-            ExampleMessage
-        )
+        assert df_decoded.schema.fields[0].dataType == schema
 
     df_encoded = df_to_protobuf(df_decoded, ExampleMessage, expanded=expanded)
 


### PR DESCRIPTION
Add top level functions `to_protobuf` and `from_protobuf` which simplify column conversion without the user having to create a `MessageConverter`.

Add top level functions `df_to_protobuf` and `df_from_protobuf` which can be passed a dataframe without a `MessageConverter`. These functions also have `expanded: bool` args which handle the expansion and contraction of data from/to the struct which is the output/input of the encoding/decoding `udf`s. The functions call into new `MessageConverter.df_to/from_protobuf` methods.

Also, since spark already uses `flatten` nomenclature, which is different from what we are doing here, we change our documentation to use the work _expand_ or _contract_ to describe that we are unpacking or packing a struct, respectively.
