### PR TITLE
fix bytearray bug

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 python 3.9.5
 poetry 1.1.11
-protoc 3.19.1
+protoc 21.1
 java adoptopenjdk-8.0.275+1

--- a/example/example_pb2.py
+++ b/example/example_pb2.py
@@ -4,9 +4,8 @@
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
-from google.protobuf import message as _message
-from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+from google.protobuf.internal import builder as _builder
 
 # @@protoc_insertion_point(imports)
 
@@ -20,79 +19,8 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
     b'\n\x15\x65xample/example.proto\x12\x07\x65xample\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/duration.proto"@\n\rSimpleMessage\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08quantity\x18\x02 \x01(\x03\x12\x0f\n\x07measure\x18\x03 \x01(\x02"+\n\rNestedMessage\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t"\x1f\n\x0e\x44\x65\x63imalMessage\x12\r\n\x05value\x18\x01 \x01(\t"\xb7\x05\n\x0e\x45xampleMessage\x12\r\n\x05int32\x18\x01 \x01(\x05\x12\r\n\x05int64\x18\x02 \x01(\x03\x12\x0e\n\x06uint32\x18\x03 \x01(\r\x12\x0e\n\x06uint64\x18\x04 \x01(\x04\x12\x0e\n\x06\x64ouble\x18\x05 \x01(\x01\x12\r\n\x05\x66loat\x18\x06 \x01(\x02\x12\x0c\n\x04\x62ool\x18\x07 \x01(\x08\x12.\n\x04\x65num\x18\x08 \x01(\x0e\x32 .example.ExampleMessage.SomeEnum\x12\x0e\n\x06string\x18\t \x01(\t\x12&\n\x06nested\x18\n \x01(\x0b\x32\x16.example.NestedMessage\x12\x12\n\nstringlist\x18\x0b \x03(\t\x12\r\n\x05\x62ytes\x18\x0c \x01(\x0c\x12\x10\n\x08sfixed32\x18\r \x01(\x0f\x12\x10\n\x08sfixed64\x18\x0e \x01(\x10\x12\x0e\n\x06sint32\x18\x0f \x01(\x11\x12\x0e\n\x06sint64\x18\x10 \x01(\x12\x12\x0f\n\x07\x66ixed32\x18\x11 \x01(\x07\x12\x0f\n\x07\x66ixed64\x18\x12 \x01(\x06\x12\x15\n\x0boneofstring\x18\x13 \x01(\tH\x00\x12\x14\n\noneofint32\x18\x14 \x01(\x05H\x00\x12-\n\x03map\x18\x15 \x03(\x0b\x32 .example.ExampleMessage.MapEntry\x12-\n\ttimestamp\x18\x16 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12+\n\x08\x64uration\x18\x17 \x01(\x0b\x32\x19.google.protobuf.Duration\x12(\n\x07\x64\x65\x63imal\x18\x18 \x01(\x0b\x32\x17.example.DecimalMessage\x1a*\n\x08MapEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"2\n\x08SomeEnum\x12\x0f\n\x0bunspecified\x10\x00\x12\t\n\x05\x66irst\x10\x01\x12\n\n\x06second\x10\x02\x42\x07\n\x05oneof"L\n\x10RecursiveMessage\x12\x0c\n\x04note\x18\x01 \x01(\t\x12*\n\x07message\x18\x02 \x01(\x0b\x32\x19.example.RecursiveMessageb\x06proto3'
 )
 
-
-_SIMPLEMESSAGE = DESCRIPTOR.message_types_by_name["SimpleMessage"]
-_NESTEDMESSAGE = DESCRIPTOR.message_types_by_name["NestedMessage"]
-_DECIMALMESSAGE = DESCRIPTOR.message_types_by_name["DecimalMessage"]
-_EXAMPLEMESSAGE = DESCRIPTOR.message_types_by_name["ExampleMessage"]
-_EXAMPLEMESSAGE_MAPENTRY = _EXAMPLEMESSAGE.nested_types_by_name["MapEntry"]
-_RECURSIVEMESSAGE = DESCRIPTOR.message_types_by_name["RecursiveMessage"]
-_EXAMPLEMESSAGE_SOMEENUM = _EXAMPLEMESSAGE.enum_types_by_name["SomeEnum"]
-SimpleMessage = _reflection.GeneratedProtocolMessageType(
-    "SimpleMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _SIMPLEMESSAGE,
-        "__module__": "example.example_pb2"
-        # @@protoc_insertion_point(class_scope:example.SimpleMessage)
-    },
-)
-_sym_db.RegisterMessage(SimpleMessage)
-
-NestedMessage = _reflection.GeneratedProtocolMessageType(
-    "NestedMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _NESTEDMESSAGE,
-        "__module__": "example.example_pb2"
-        # @@protoc_insertion_point(class_scope:example.NestedMessage)
-    },
-)
-_sym_db.RegisterMessage(NestedMessage)
-
-DecimalMessage = _reflection.GeneratedProtocolMessageType(
-    "DecimalMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _DECIMALMESSAGE,
-        "__module__": "example.example_pb2"
-        # @@protoc_insertion_point(class_scope:example.DecimalMessage)
-    },
-)
-_sym_db.RegisterMessage(DecimalMessage)
-
-ExampleMessage = _reflection.GeneratedProtocolMessageType(
-    "ExampleMessage",
-    (_message.Message,),
-    {
-        "MapEntry": _reflection.GeneratedProtocolMessageType(
-            "MapEntry",
-            (_message.Message,),
-            {
-                "DESCRIPTOR": _EXAMPLEMESSAGE_MAPENTRY,
-                "__module__": "example.example_pb2"
-                # @@protoc_insertion_point(class_scope:example.ExampleMessage.MapEntry)
-            },
-        ),
-        "DESCRIPTOR": _EXAMPLEMESSAGE,
-        "__module__": "example.example_pb2"
-        # @@protoc_insertion_point(class_scope:example.ExampleMessage)
-    },
-)
-_sym_db.RegisterMessage(ExampleMessage)
-_sym_db.RegisterMessage(ExampleMessage.MapEntry)
-
-RecursiveMessage = _reflection.GeneratedProtocolMessageType(
-    "RecursiveMessage",
-    (_message.Message,),
-    {
-        "DESCRIPTOR": _RECURSIVEMESSAGE,
-        "__module__": "example.example_pb2"
-        # @@protoc_insertion_point(class_scope:example.RecursiveMessage)
-    },
-)
-_sym_db.RegisterMessage(RecursiveMessage)
-
+_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "example.example_pb2", globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -277,6 +277,8 @@ class MessageConverter:
         kwargs = options or {}
 
         def decoder(s: bytes) -> dict:
+            if isinstance(s, bytearray):
+                s = bytes(s)
             return self.message_to_dict(message_type.FromString(s), **kwargs)
 
         return decoder

--- a/poetry.lock
+++ b/poetry.lock
@@ -193,8 +193,8 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "protobuf"
-version = "3.20.0"
-description = "Protocol Buffers"
+version = "4.21.1"
+description = ""
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -405,30 +405,20 @@ pluggy = [
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 protobuf = [
-    {file = "protobuf-3.20.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9d0f3aca8ca51c8b5e204ab92bd8afdb2a8e3df46bd0ce0bd39065d79aabcaa4"},
-    {file = "protobuf-3.20.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:001c2160c03b6349c04de39cf1a58e342750da3632f6978a1634a3dcca1ec10e"},
-    {file = "protobuf-3.20.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5b5860b790498f233cdc8d635a17fc08de62e59d4dcd8cdb6c6c0d38a31edf2b"},
-    {file = "protobuf-3.20.0-cp310-cp310-win32.whl", hash = "sha256:0b250c60256c8824219352dc2a228a6b49987e5bf94d3ffcf4c46585efcbd499"},
-    {file = "protobuf-3.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:a1eebb6eb0653e594cb86cd8e536b9b083373fca9aba761ade6cd412d46fb2ab"},
-    {file = "protobuf-3.20.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bc14037281db66aa60856cd4ce4541a942040686d290e3f3224dd3978f88f554"},
-    {file = "protobuf-3.20.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:47257d932de14a7b6c4ae1b7dbf592388153ee35ec7cae216b87ae6490ed39a3"},
-    {file = "protobuf-3.20.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fbcbb068ebe67c4ff6483d2e2aa87079c325f8470b24b098d6bf7d4d21d57a69"},
-    {file = "protobuf-3.20.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:542f25a4adf3691a306dcc00bf9a73176554938ec9b98f20f929a044f80acf1b"},
-    {file = "protobuf-3.20.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fd7133b885e356fa4920ead8289bb45dc6f185a164e99e10279f33732ed5ce15"},
-    {file = "protobuf-3.20.0-cp37-cp37m-win32.whl", hash = "sha256:8d84453422312f8275455d1cb52d850d6a4d7d714b784e41b573c6f5bfc2a029"},
-    {file = "protobuf-3.20.0-cp37-cp37m-win_amd64.whl", hash = "sha256:52bae32a147c375522ce09bd6af4d2949aca32a0415bc62df1456b3ad17c6001"},
-    {file = "protobuf-3.20.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:25d2fcd6eef340082718ec9ad2c58d734429f2b1f7335d989523852f2bba220b"},
-    {file = "protobuf-3.20.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:88c8be0558bdfc35e68c42ae5bf785eb9390d25915d4863bbc7583d23da77074"},
-    {file = "protobuf-3.20.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:38fd9eb74b852e4ee14b16e9670cd401d147ee3f3ec0d4f7652e0c921d6227f8"},
-    {file = "protobuf-3.20.0-cp38-cp38-win32.whl", hash = "sha256:7dcd84dc31ebb35ade755e06d1561d1bd3b85e85dbdbf6278011fc97b22810db"},
-    {file = "protobuf-3.20.0-cp38-cp38-win_amd64.whl", hash = "sha256:1eb13f5a5a59ca4973bcfa2fc8fff644bd39f2109c3f7a60bd5860cb6a49b679"},
-    {file = "protobuf-3.20.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1d24c81c2310f0063b8fc1c20c8ed01f3331be9374b4b5c2de846f69e11e21fb"},
-    {file = "protobuf-3.20.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:8be43a91ab66fe995e85ccdbdd1046d9f0443d59e060c0840319290de25b7d33"},
-    {file = "protobuf-3.20.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7a53d4035427b9dbfbb397f46642754d294f131e93c661d056366f2a31438263"},
-    {file = "protobuf-3.20.0-cp39-cp39-win32.whl", hash = "sha256:32bf4a90c207a0b4e70ca6dd09d43de3cb9898f7d5b69c2e9e3b966a7f342820"},
-    {file = "protobuf-3.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:6efe066a7135233f97ce51a1aa007d4fb0be28ef093b4f88dac4ad1b3a2b7b6f"},
-    {file = "protobuf-3.20.0-py2.py3-none-any.whl", hash = "sha256:4eda68bd9e2a4879385e6b1ea528c976f59cd9728382005cc54c28bcce8db983"},
-    {file = "protobuf-3.20.0.tar.gz", hash = "sha256:71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702"},
+    {file = "protobuf-4.21.1-cp310-abi3-win32.whl", hash = "sha256:52c1e44e25f2949be7ffa7c66acbfea940b0945dd416920231f7cb30ea5ac6db"},
+    {file = "protobuf-4.21.1-cp310-abi3-win_amd64.whl", hash = "sha256:72d357cc4d834cc85bd957e8b8e1f4b64c2eac9ca1a942efeb8eb2e723fca852"},
+    {file = "protobuf-4.21.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:3767c64593a49c7ac0accd08ed39ce42744405f0989d468f0097a17496fdbe84"},
+    {file = "protobuf-4.21.1-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:0d4719e724472e296062ba8e82a36d64693fcfdb550d9dff98af70ca79eafe3d"},
+    {file = "protobuf-4.21.1-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:a4c0c6f2f95a559e59a0258d3e4b186f340cbdc5adec5ce1bc06d01972527c88"},
+    {file = "protobuf-4.21.1-cp37-cp37m-win32.whl", hash = "sha256:32fff501b6df3050936d1839b80ea5899bf34db24792d223d7640611f67de15a"},
+    {file = "protobuf-4.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b3d7d4b4945fe3c001403b6c24442901a5e58c0a3059290f5a63523ed4435f82"},
+    {file = "protobuf-4.21.1-cp38-cp38-win32.whl", hash = "sha256:34400fd76f85bdae9a2e9c1444ea4699c0280962423eff4418765deceebd81b5"},
+    {file = "protobuf-4.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:c8829092c5aeb61619161269b2f8a2e36fd7cb26abbd9282d3bc453f02769146"},
+    {file = "protobuf-4.21.1-cp39-cp39-win32.whl", hash = "sha256:2b35602cb65d53c168c104469e714bf68670335044c38eee3c899d6a8af03ffc"},
+    {file = "protobuf-4.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:3f2ed842e8ca43b790cb4a101bcf577226e0ded98a6a6ba2d5e12095a08dc4da"},
+    {file = "protobuf-4.21.1-py2.py3-none-any.whl", hash = "sha256:b309fda192850ac4184ca1777aab9655564bc8d10a9cc98f10e1c8bf11295c22"},
+    {file = "protobuf-4.21.1-py3-none-any.whl", hash = "sha256:79cd8d0a269b714f6b32641f86928c718e8d234466919b3f552bfb069dbb159b"},
+    {file = "protobuf-4.21.1.tar.gz", hash = "sha256:5d9b5c8270461706973c3871c6fbdd236b51dfe9dab652f1fb6a36aa88287e47"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},


### PR DESCRIPTION
Bumping protoc/protobuf. Newer versions of protobuf result in a bytearray error in the decoder. We fix that here by ensuring the value passed to FromString is of type bytes.