### PR TITLE
convert int64 types to long

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ df_reencoded = df_unexpanded.select(
 Internally, `pbspark` uses protobuf's `MessageToDict`, which deserializes everything into JSON compatible objects by default. The exceptions are
 * protobuf's bytes type, which `MessageToDict` would decode to a base64-encoded string; `pbspark` will decode any bytes fields directly to a spark `BinaryType`.
 * protobuf's well known type, Timestamp type, which `MessageToDict` would decode to a string; `pbspark` will decode any Timestamp messages directly to a spark `TimestampType` (via python datetime objects).
+* protobuf's int64 types, which `MessageToDict` would decode to a string for compatibility reasons; `pbspark` will decode these to `LongType`.
 
 ### Custom conversion of message types
 

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -79,6 +79,9 @@ class _Printer(json_format._Printer):  # type: ignore
             and field.type == FieldDescriptor.TYPE_BYTES
         ):
             return value
+        # don't convert int64s to string (protobuf does this for js precision compat)
+        elif field.cpp_type in json_format._INT64_TYPES:
+            return value
         return super()._FieldToJsonObject(field, value)
 
 

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -46,6 +46,8 @@ def example():
     ex = ExampleMessage(
         string="asdf",
         int32=69,
+        int64=789,
+        uint64=404,
         float=4.20,
         stringlist=["one", "two", "three"],
         bytes=b"something",
@@ -152,6 +154,8 @@ def test_get_decoder(example):
     assert decoded == mc.message_to_dict(example)
     expected = {
         "int32": 69,
+        "int64": 789,
+        "uint64": 404,
         "float": 4.2,
         "enum": "first",
         "string": "asdf",


### PR DESCRIPTION
Right now int64 types processed as strings by protobuf for "javascript precision compatibility", which would render them null when converted into spark. Didn't previously catch this because int64 types weren't present in fixtures. This change properly converts int64, uint64 to LongType.