### PR TITLE
Add logic to detect and handle circular loops, and optionally ignore deprecated fields

### DIFF
--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -255,7 +255,7 @@ class MessageConverter:
         options = options or {}
         use_camelcase = not options.get("preserving_proto_field_name", False)
         ignore_deprecated = options.get("ignore_deprecated", False)
-        fail_on_loop = options.get("fail_on_loop", False)
+        ignore_circular_definitions = options.get("ignore_circular_definitions", False)
 
         schema = []
         if inspect.isclass(descriptor) and issubclass(descriptor, Message):
@@ -280,7 +280,7 @@ class MessageConverter:
             # Check for recursive loops in proto definition
             if field.message_type != None:  # noqa ("is None" is not the same as "!= None" here)
                 if field_full_name in _seen_descriptors_:
-                    if fail_on_loop:
+                    if ignore_circular_definitions:
                         logging.warning(f"Circular protobuf definition detected! Ignoring field: {field_full_name}")
                         continue
                     else:

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -1,6 +1,8 @@
 import inspect
+import logging
 import typing as t
 from contextlib import contextmanager
+from copy import copy
 from functools import wraps
 
 from google.protobuf import json_format
@@ -237,34 +239,56 @@ class MessageConverter:
         return parser.ConvertMessage(value=value, message=message, path=None)
 
     def get_spark_schema(
-        self,
-        descriptor: t.Union[t.Type[Message], Descriptor],
-        options: t.Optional[dict] = None,
+            self,
+            descriptor: t.Union[t.Type[Message], Descriptor],
+            options: t.Optional[dict] = None,
+            _seen_descriptors: t.Optional[set] = None
     ) -> DataType:
         """Generate a spark schema from a message type or descriptor
-
         Given a message type generated from protoc (or its descriptor),
         create a spark schema derived from the protobuf schema when
         serializing with ``MessageToDict``.
         """
+        # track which descriptors have been seen in the current proto graph (for loop identification)
+        _seen_descriptors_ = copy(_seen_descriptors) or set()
+
         options = options or {}
         use_camelcase = not options.get("preserving_proto_field_name", False)
+        ignore_deprecated = options.get("ignore_deprecated", False)
+
         schema = []
         if inspect.isclass(descriptor) and issubclass(descriptor, Message):
             descriptor_ = descriptor.DESCRIPTOR
         else:
             descriptor_ = descriptor  # type: ignore[assignment]
+        _seen_descriptors_.add(descriptor_.full_name)
+
         full_name = descriptor_.full_name
         if full_name in self._message_type_to_spark_type_map:
             return self._message_type_to_spark_type_map[full_name]
+
         for field in descriptor_.fields:
+            field_full_name = field.message_type.full_name
+            if field.has_options:
+                field_options = field.GetOptions()
+
+                # Optionally ignore deprecated fields
+                if field_options.deprecated and ignore_deprecated:
+                    continue
+
+            # Check for recursive loops in proto definition
+            if field.message_type != None:  # noqa ("is None" is not the same as "!= None" here)
+                if field_full_name in _seen_descriptors_:
+                    logging.warning(f"Circular protobuf definition detected! Ignoring field: {field_full_name}")
+                    continue
+
             spark_type: DataType
             if field.cpp_type == FieldDescriptor.CPPTYPE_MESSAGE:
                 full_name = field.message_type.full_name
                 if full_name in self._message_type_to_spark_type_map:
                     spark_type = self._message_type_to_spark_type_map[full_name]
                 else:
-                    spark_type = self.get_spark_schema(field.message_type, options)
+                    spark_type = self.get_spark_schema(field.message_type, options, _seen_descriptors_)
             # protobuf converts to/from b64 strings, but we prefer to stay as bytes
             elif (
                 field.cpp_type == FieldDescriptor.CPPTYPE_STRING

--- a/pbspark/_proto.py
+++ b/pbspark/_proto.py
@@ -239,10 +239,10 @@ class MessageConverter:
         return parser.ConvertMessage(value=value, message=message, path=None)
 
     def get_spark_schema(
-            self,
-            descriptor: t.Union[t.Type[Message], Descriptor],
-            options: t.Optional[dict] = None,
-            _seen_descriptors: t.Optional[set] = None
+        self,
+        descriptor: t.Union[t.Type[Message], Descriptor],
+        options: t.Optional[dict] = None,
+        _seen_descriptors: t.Optional[set] = None
     ) -> DataType:
         """Generate a spark schema from a message type or descriptor
         Given a message type generated from protoc (or its descriptor),


### PR DESCRIPTION
Add options for creating spark struct to ignore circularly defined fields and/or deprecated fields. This PR is a no-op change, meaning existing behavior should not be impacted.

I was not able to get the tests up and running on my local fork (make gen and make test both gave errors), so these will need to have tests added to validate behavior is as expected. I was able to informally validate behavior is as expected in a notebook.

It may be worth separating the recursive functionality of `get_spark_schema` from the public interface to avoid the need to surface `_seen_descriptors` publicly (e.g. keep the current entry point and hide the recursion behind something like `_ get_spark_schema`